### PR TITLE
fix column in selection

### DIFF
--- a/lib/tree-sitter-panel.tsx
+++ b/lib/tree-sitter-panel.tsx
@@ -24,7 +24,7 @@ export class TreeSitterPanel extends React.Component<Props, State> {
     if (userInteraction && this.props.textEditor) {
       this.props.textEditor.setSelectedBufferRange([
         [tsNode.startPosition.row, tsNode.startPosition.column],
-        [tsNode.endPosition.row, tsNode.endPosition.column]
+        [tsNode.endPosition.row, tsNode.endPosition.column - 1]
       ]);
     }
 


### PR DESCRIPTION
with this PR, the selected text in the editor resembles the actual span of the AST.
I am confident, that the end-column is 'exclusive'. Before, the 'x' in line 3 was included in the selection.

![column-span-fix](https://user-images.githubusercontent.com/4367963/36561962-ad04e0f6-1815-11e8-9281-47ba45cf9cbd.png)
